### PR TITLE
feat: proxy search requests through backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -10,4 +10,10 @@ A fun and colorful static blog showcasing a light/dark mode toggle using vanilla
 - Light/dark theme toggle with persistence and system preference support
 - Responsive layout for small screens
 - Four sample posts to get you started
-- Search bar powered by the OpenAI API (requires an API key)
+- Search bar powered by the OpenAI API via a backend proxy (set `OPENAI_API_KEY` and run the server)
+
+## Running locally
+
+1. Install dependencies with `npm install`.
+2. Set your OpenAI API key in the `OPENAI_API_KEY` environment variable.
+3. Start the server with `npm start` and open the site in your browser.

--- a/package.json
+++ b/package.json
@@ -1,1 +1,13 @@
-
+{
+  "name": "blog",
+  "version": "1.0.0",
+  "description": "Playful blog with backend-powered search",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -28,30 +28,17 @@ toggleBtn.addEventListener('click', () => {
 async function performSearch() {
   const query = searchInput.value.trim();
   if (!query) return;
-  let apiKey = localStorage.getItem('openai_api_key');
-  if (!apiKey) {
-    apiKey = prompt('Enter your OpenAI API key');
-    if (!apiKey) return;
-    localStorage.setItem('openai_api_key', apiKey);
-  }
   searchResults.textContent = 'Searching...';
   try {
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    const response = await fetch('/api/search', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${apiKey}`,
       },
-      body: JSON.stringify({
-        model: 'gpt-3.5-turbo',
-        messages: [
-          { role: 'system', content: 'You help users search a playful blog with concise answers.' },
-          { role: 'user', content: query },
-        ],
-      }),
+      body: JSON.stringify({ query }),
     });
     const data = await response.json();
-    const answer = data.choices?.[0]?.message?.content?.trim();
+    const answer = data.answer?.trim();
     searchResults.textContent = answer || 'No results found.';
   } catch (err) {
     console.error(err);

--- a/server.js
+++ b/server.js
@@ -1,0 +1,36 @@
+const express = require('express');
+
+const app = express();
+app.use(express.json());
+
+app.post('/api/search', async (req, res) => {
+  const { query } = req.body;
+  if (!query) return res.status(400).json({ error: 'Missing query' });
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          { role: 'system', content: 'You help users search a playful blog with concise answers.' },
+          { role: 'user', content: query },
+        ],
+      }),
+    });
+    const data = await response.json();
+    const answer = data.choices?.[0]?.message?.content?.trim();
+    res.json({ answer });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Error fetching results' });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- use backend server to call OpenAI with environment API key
- update client to query new proxy endpoint
- document setup and ignore node modules

## Testing
- ⚠️ `npm install` (403 Forbidden installing dependencies)
- ⚠️ `npm test` (no test specified)
- ⚠️ `npm start` (Cannot find module 'express')


------
https://chatgpt.com/codex/tasks/task_e_68ab84ba7eec832099d66ecf9686c400