### PR TITLE
Use Responses API for search

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A fun and colorful static blog showcasing a light/dark mode toggle using vanilla
 - Light/dark theme toggle with persistence and system preference support
 - Responsive layout for small screens
 - Four sample posts to get you started
-- Search bar powered by the OpenAI API via a backend proxy (set `OPENAI_API_KEY` and run the server)
+- Search bar powered by the OpenAI Responses API with developer-style instructions (set `OPENAI_API_KEY` and run the server)
 
 ## Running locally
 

--- a/server.js
+++ b/server.js
@@ -7,22 +7,27 @@ app.post('/api/search', async (req, res) => {
   const { query } = req.body;
   if (!query) return res.status(400).json({ error: 'Missing query' });
   try {
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    const response = await fetch('https://api.openai.com/v1/responses', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
       },
       body: JSON.stringify({
-        model: 'gpt-3.5-turbo',
-        messages: [
-          { role: 'system', content: 'You help users search a playful blog with concise answers.' },
-          { role: 'user', content: query },
-        ],
+        model: 'gpt-5',
+        instructions: 'Provide concise answers to help users search a playful blog.',
+        input: query,
       }),
     });
     const data = await response.json();
-    const answer = data.choices?.[0]?.message?.content?.trim();
+    const answer =
+      data.output_text?.trim() ||
+      data.output
+        ?.map((item) =>
+          item.content?.map((c) => c.text || '').join('')
+        )
+        .join('')
+        .trim();
     res.json({ answer });
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## Summary
- replace Chat Completions call with Responses API in `server.js`
- parse `output_text` and developer instructions for concise blog answers
- update README to mention new Responses-based search

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ab85cef2ec8320a257ef320667720e