### PR TITLE
fix: support fetch in older node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "node-fetch": "^3.3.2"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,4 +1,7 @@
 const express = require('express');
+// Use the built-in fetch in newer versions of Node.
+// Fall back to `node-fetch` when running on older runtimes where `fetch` is undefined.
+const fetch = global.fetch || ((...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args)));
 
 const app = express();
 app.use(express.json());


### PR DESCRIPTION
## Summary
- fallback to `node-fetch` when global `fetch` is unavailable
- add `node-fetch` dependency

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*

------
https://chatgpt.com/codex/tasks/task_e_68ab876114c883209902ea69ab268cc9