### PR TITLE
Handle missing AI output

### DIFF
--- a/script.js
+++ b/script.js
@@ -38,11 +38,14 @@ async function performSearch() {
       body: JSON.stringify({ query }),
     });
     const data = await response.json();
+    if (!response.ok) {
+      throw new Error(data.error || 'Error fetching results.');
+    }
     const answer = data.answer?.trim();
     searchResults.textContent = answer || 'No results found.';
   } catch (err) {
     console.error(err);
-    searchResults.textContent = 'Error fetching results.';
+    searchResults.textContent = err.message || 'Error fetching results.';
   }
 }
 

--- a/server.js
+++ b/server.js
@@ -26,14 +26,17 @@ app.post('/api/search', async (req, res) => {
       }),
     });
     const data = await response.json();
-    const answer =
-      data.output_text?.trim() ||
-      data.output
+
+    let answer = data.output_text?.trim();
+    if (!answer) {
+      answer = data.output
         ?.map((item) =>
           item.content?.map((c) => c.text || '').join('')
         )
-        .join('')
-        .trim();
+        ?.join('')
+        ?.trim();
+    }
+
     res.json({ answer });
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## Summary
- guard against missing `data.output` in search API to avoid server crashes
- show backend error messages in the client search UI

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68ab8c5f336c832097c7e1dfe942d82c