### PR TITLE
Improve OpenAI error reporting

### DIFF
--- a/server.js
+++ b/server.js
@@ -25,6 +25,13 @@ app.post('/api/search', async (req, res) => {
         input: query,
       }),
     });
+
+    if (!response.ok) {
+      const errData = await response.json().catch(() => ({}));
+      const message = errData.error?.message || errData.error || 'Error fetching results';
+      return res.status(response.status).json({ error: message });
+    }
+
     const data = await response.json();
 
     let answer = data.output_text?.trim();
@@ -40,7 +47,7 @@ app.post('/api/search', async (req, res) => {
     res.json({ answer });
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Error fetching results' });
+    res.status(500).json({ error: err.message || 'Error fetching results' });
   }
 });
 


### PR DESCRIPTION
## Summary
- handle non-OK responses from OpenAI and return the server status code with the API's error message
- surface underlying error messages from the backend instead of a generic placeholder

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8db3cbb88320a4dfa8e6c89b87ca