### PR TITLE
Fix missing content parsing in OpenAI response

### DIFF
--- a/server.js
+++ b/server.js
@@ -36,12 +36,14 @@ app.post('/api/search', async (req, res) => {
 
     let answer = data.output_text?.trim();
     if (!answer) {
-      answer = data.output
-        ?.map((item) =>
-          item.content?.map((c) => c.text || '').join('')
+      answer = (data.output || [])
+        .map((item) =>
+          (item.content || [])
+            .map((c) => c.text || '')
+            .join('')
         )
-        ?.join('')
-        ?.trim();
+        .join('')
+        .trim();
     }
 
     res.json({ answer });


### PR DESCRIPTION
## Summary
- Prevent server crashes when OpenAI's response lacks content blocks by safely iterating through `data.output`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8fb2773083208996b308cbdbc99d